### PR TITLE
add value prop for Transactional annotation

### DIFF
--- a/src/Annotation/Transactional.php
+++ b/src/Annotation/Transactional.php
@@ -12,4 +12,5 @@ namespace Ray\CakeDbModule\Annotation;
  */
 final class Transactional
 {
+    public $value;
 }


### PR DESCRIPTION
fix the test failed as following.

```
1) Ray\CakeDbModule\CakeDbModuleTest::testTransactional
Doctrine\Common\Annotations\AnnotationException: [Creation Error] The annotation @Transactional declared on method Ray\CakeDbModule\FakeModel::dbError() does not accept any values, but got {"value":"default"}.
```
